### PR TITLE
Fix evaluate example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Run a throw away instamce of kimai for evauation ot testing,  This is built agai
 
 ```bash
 docker run --rm -ti -p 8001:8001 --name kimai2 kimai/kimai2:apache-debian-master-prod
-docker exec kimai2 bin/console kimai:create-user admin admin@example.com ROLE_SUPER_ADMIN admin
-docker exec kimai2 bin/console kimai:reset-dev
+docker exec kimai2 /opt/kimai/bin/console kimai:create-user admin admin@example.com ROLE_SUPER_ADMIN adminsecret
+docker exec kimai2 /opt/kimai/bin/console kimai:reset-dev
 ```
 
 ### Production


### PR DESCRIPTION
* Add the full path to the docker exec command.
* Make the admin-password longer to fullfill constraints.

Note: I'm still not fully satisfied with this: The second command:

```
/opt/kimai/bin/console kimai:reset-dev
```
should bootstrap the database with example data (cmp [https://www.kimai.org/documentation/installation.html](https://www.kimai.org/documentation/installation.html)). But it destroys the database and when logging in, you will get an error "no such table: kimai2_roles_permissions".
Though I suppose this is not this Docker project's fault, but a Kimai2 upstream problem. Should this command be left out of the Docker example until it works again?
