### PR TITLE
Multiple volumes fix and support for secure LDAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ services:
     volumes:
       - public:/opt/kimai/public
       - var:/opt/kimai/var
+      # - ./ldap.conf:/etc/openldap/ldap.conf:z
+      # - ./ROOT-CA.pem:/etc/ssl/certs/ROOT-CA.pem:z
     restart: unless-stopped
     healthcheck:
       test: wget --spider http://nginx || exit 1

--- a/README.md
+++ b/README.md
@@ -50,11 +50,10 @@ services:
       - 8001:80
     volumes:
       - ./nginx_site.conf:/etc/nginx/conf.d/default.conf
+      - public:/opt/kimai/public
     restart: unless-stopped
     depends_on:
       - kimai
-    volumes:
-      - public:/opt/kimai/public
     healthcheck:
       test:  wget --spider http://nginx/health || exit 1 
       interval: 20s

--- a/ROOT-CA.pem
+++ b/ROOT-CA.pem
@@ -1,0 +1,1 @@
+# Add your Root CA here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,11 +25,10 @@ services:
       - 8001:80
     volumes:
       - ./nginx_site.conf:/etc/nginx/conf.d/default.conf
+      - public:/opt/kimai/public
     restart: unless-stopped
     depends_on:
       - kimai
-    volumes:
-      - public:/opt/kimai/public
     healthcheck:
       test:  wget --spider http://nginx/health || exit 1 
       interval: 20s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
     volumes:
       - public:/opt/kimai/public
       - var:/opt/kimai/var
+      # - ./ldap.conf:/etc/openldap/ldap.conf:z
+      # - ./ROOT-CA.pem:/etc/ssl/certs/ROOT-CA.pem:z
     restart: unless-stopped
     healthcheck:
       test: wget --spider http://nginx || exit 1

--- a/ldap.conf
+++ b/ldap.conf
@@ -1,0 +1,14 @@
+#
+# LDAP Defaults
+#
+
+# See ldap.conf(5) for details
+# This file should be world readable but not world writable.
+
+#BASE   dc=example,dc=com
+#URI    ldap://ldap.example.com ldap://ldap-master.example.com:666
+
+#SIZELIMIT      12
+#TIMELIMIT      15
+#DEREF          never
+TLS_CACERT      /etc/ssl/certs/MY-ROOT-CA.pem

--- a/ldap.conf
+++ b/ldap.conf
@@ -11,4 +11,4 @@
 #SIZELIMIT      12
 #TIMELIMIT      15
 #DEREF          never
-TLS_CACERT      /etc/ssl/certs/MY-ROOT-CA.pem
+TLS_CACERT      /etc/ssl/certs/ROOT-CA.pem


### PR DESCRIPTION
Not sure if this is the best way.  I commented out the volume files to show where a user would add the proper configuration files.  I added the ldap.conf and a ROOT-CA.pem file that can be used to add their own CA certificate