### PR TITLE
Add additional options to customize the build and fix TZ not being ca…

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -5,20 +5,28 @@ function usage {
     echo "VERSIONS is a space delimited list of branches and or tags."
     echo "e.g. 1.7 fixes/foo"
     echo
+    echo " -b The images bases, e.g. apache-debian fpm-alpine"
     echo " -t The timezone, e.g. Europe/London"
+    echo " -s The stages, e.g. dev prod"
+    echo " -k Do not use Docker Build Kit"
     echo " -c Use the docker cache, default behaviour is to add --nocache"
     echo " -h Show help"
 }
 
 export DOCKER_BUILDKIT=1
 export TZ=Europe/London
+export STAGES="dev prod"
+export BASES="apache-debian fpm-alpine"
 NOCACHE="--no-cache"
 
-USAGE="$0 [-t TIMEZONE] [-c] [-h] VERSIONS"
+USAGE="$0 [-t TIMEZONE] [-b BASES] [-s STAGES] [-k] [-c] [-h] VERSIONS"
 
-while getopts "t:ch" options; do
+while getopts "b:t:s:kch" options; do
     case $options in
+        b) export BASES="$OPTARG";;
+        s) export STAGES="$OPTARG";;
         t) export TZ="$OPTARG";;
+        k) unset DOCKER_BUILDKIT;;
         c) unset NOCACHE;;
         h) echo $USAGE; usage; exit 0;;
     esac
@@ -30,9 +38,9 @@ export KIMAIS=$@
 echo $KIMAIS
 
 for KIMAI in $KIMAIS master; do
-    for STAGE_NAME in dev prod; do
-        for BASE in apache-debian fpm-alpine; do
-            docker build $NOCACHE -t kimai/kimai2:${BASE}-${KIMAI}-${STAGE_NAME} --build-arg KIMAI=${KIMAI} --build-arg BASE=${BASE} --target=${STAGE_NAME} $(dirname $0)/..
+    for STAGE_NAME in $STAGES; do
+        for BASE in $BASES; do
+            docker build $NOCACHE -t kimai/kimai2:${BASE}-${KIMAI}-${STAGE_NAME} --build-arg KIMAI=${KIMAI} --build-arg BASE=${BASE} --build-arg TZ=${TZ} --target=${STAGE_NAME} $(dirname $0)/..
         done
     done
 done


### PR DESCRIPTION
Add additional options to customize the build and fix TZ not being carried through the build.  The -k option allows you to obuild without the DOCKER_BUILDKIT option to allow the images to build on systems with older docker versions

Fixes #82 and adds feature #83 and addresses workaround for #39 