### PR TITLE
Made the build tools consistent

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -25,11 +25,12 @@ while getopts "t:ch" options; do
 done
 
 shift $((OPTIND-1))
-export KIMAIS=$@
 
-echo $KIMAIS
+if [ ! -z "$1" ] && [ -z "$KIMAIS" ]; then
+    KIMAIS=$@
+fi
 
-for KIMAI in $KIMAIS master; do
+for KIMAI in $KIMAIS; do
     for STAGE_NAME in dev prod; do
         for BASE in apache-debian fpm-alpine; do
             docker build $NOCACHE -t kimai/kimai2:${BASE}-${KIMAI}-${STAGE_NAME} --build-arg KIMAI=${KIMAI} --build-arg BASE=${BASE} --target=${STAGE_NAME} $(dirname $0)/..

--- a/bin/push.sh
+++ b/bin/push.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-for KIMAI in $@; do
+if [ ! -z "$1" ] && [ -z "$KIMAIS" ]; then
+    KIMAIS=$@
+fi
+
+for KIMAI in $KIMAIS; do
     docker push kimai/kimai2:apache-debian-$KIMAI-dev
     docker push kimai/kimai2:fpm-alpine-$KIMAI-dev
     docker push kimai/kimai2:apache-debian-$KIMAI-prod

--- a/bin/simple-test.sh
+++ b/bin/simple-test.sh
@@ -41,6 +41,7 @@ function test_container {
     URL=$1
     cmd=$(make_cmd "${@:2}")
     echo -e ${COL_GREEN}${KIMAI} ${@:2}${COL_RESET} starting...
+    echo $cmd
     $cmd 2>&1 > /dev/null
     STATUS=$(isready $URL)
     if [ "$STATUS" == "FAILED" ]; then
@@ -116,6 +117,10 @@ function make_cmd {
     cmd="$cmd up -d"
     echo $cmd
 }
+
+if [ ! -z "$1" ] && [ -z "$KIMAIS" ]; then
+    KIMAIS=$@
+fi
 
 for KIMAI in $KIMAIS; do 
     export KIMAI


### PR DESCRIPTION
The shells scripots took different parameters and different env vars.  Now consistently it is either export KIMAIS="xx yy zz" or ./bin/tool xx yy zz

Also no longer build master as that is misleading, #81 