### PR TITLE
Fixes memory limit in dev image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -224,14 +224,14 @@ ENTRYPOINT /startup.sh
 FROM base AS dev
 # copy kimai develop source
 COPY --from=git-dev --chown=www-data:www-data /opt/kimai /opt/kimai
+COPY monolog-dev.yaml /opt/kimai/config/packages/dev/monolog.yaml
 # do the composer deps installation
 RUN export COMPOSER_HOME=/composer && \
     composer install --working-dir=/opt/kimai --optimize-autoloader && \
     composer clearcache && \
     composer require --working-dir=/opt/kimai laminas/laminas-ldap && \
     chown -R www-data:www-data /opt/kimai && \
-    sed "s/128M/256M/g" /usr/local/etc/php/php.ini-development > /usr/local/etc/php/php.ini
-COPY monolog-dev.yaml /opt/kimai/config/packages/dev/monolog.yaml
+    sed "s/128M/-1/g" /usr/local/etc/php/php.ini-development > /usr/local/etc/php/php.ini
 ENV APP_ENV=dev
 USER www-data
 
@@ -239,12 +239,12 @@ USER www-data
 FROM base AS prod
 # copy kimai production source
 COPY --from=git-prod --chown=www-data:www-data /opt/kimai /opt/kimai
+COPY monolog-prod.yaml /opt/kimai/config/packages/prod/monolog.yaml
 # do the composer deps installation
 RUN export COMPOSER_HOME=/composer && \
     composer install --working-dir=/opt/kimai --no-dev --optimize-autoloader && \
     composer clearcache && \
     composer require --working-dir=/opt/kimai laminas/laminas-ldap && \
     chown -R www-data:www-data /opt/kimai
-COPY monolog-prod.yaml /opt/kimai/config/packages/prod/monolog.yaml
 ENV APP_ENV=prod
 USER www-data

--- a/bin/simple-test.sh
+++ b/bin/simple-test.sh
@@ -2,7 +2,7 @@
 
 BASEDIR=$(realpath $(dirname $0)/..)
 COMPOSEDIR="$BASEDIR/compose"
-SLEEP_COUNT=6
+SLEEP_COUNT=10
 SLEEP_DURATION=5
 
 ESC_SEQ="\x1b["
@@ -15,16 +15,16 @@ function main {
     cleanup all
     cleanup volumes
 
-    test_container http://localhost:8001 base apache.dev
-    test_container http://localhost:8001 base apache.dev apache.prod
-    test_container http://localhost:8001 base apache.dev mysql
-    test_container http://localhost:8001 base apache.dev apache.prod mysql
-    test_container http://localhost:8002 base fpm.dev nginx
-    test_container http://localhost:8002 base fpm.prod nginx
-    test_container http://localhost:8002 base fpm.dev nginx mysql
-    test_container http://localhost:8002 base fpm.prod nginx mysql
-    test_container http://localhost:8001 base apache.dev ldap
-    test_container http://localhost:8002 base fpm.dev nginx ldap
+    test_container http://localhost:8001/en/login base apache.dev
+    test_container http://localhost:8001/en/login base apache.dev apache.prod
+    test_container http://localhost:8001/en/login base apache.dev mysql
+    test_container http://localhost:8001/en/login base apache.dev apache.prod mysql
+    test_container http://localhost:8002/en/login base fpm.dev nginx
+    test_container http://localhost:8002/en/login base fpm.prod nginx
+    test_container http://localhost:8002/en/login base fpm.dev nginx mysql
+    test_container http://localhost:8002/en/login base fpm.prod nginx mysql
+    test_container http://localhost:8001/en/login base apache.dev ldap
+    test_container http://localhost:8002/en/login base fpm.dev nginx ldap
 
     finally
 }


### PR DESCRIPTION
The kimai:reset-dev command is blowing the 256m memory limit.  I am a little concerned that this removes the memory limit for the www php as well as the cli but the dev image right?

Other options:

 1. Run kimai:reset-dev as part of the dev image tear up using a temporary php.ini
    1. Pros: Keeps the mem limit safe in the www env
    1. Cons: Complicates startup.sh even further, and the command can't be rerun in that image later
 1. Add docs for how to mount your own php.ini at run time.  
    1. Pros: Keeps the dev image safe in www env, makes it not our problem
    1. Cons: Doesn't feel right, people won't RTFM and raise issues anyway
 1. Configure the environment to the cli commands run with no memory limit
    1. Pros: Elegant, keeps www env safe, the _right_ way of doing it
    1. Cons: I'm not sure how to do this in the php docker image.

I'd like to merge this now and then raise a ticket to pick one of the above as a future fix but I'm open to advice.