### PR TITLE
Add docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,10 +124,18 @@ RUN apk add --no-cache \
         libldap \
         libpng \
         libzip \
-        libxslt-dev && \
+        libxslt-dev \
+        fcgi && \
     touch /use_fpm
 
 EXPOSE 9000
+
+HEALTHCHECK --interval=20s --timeout=10s --retries=3 \
+    CMD \
+    SCRIPT_NAME=/ping \
+    SCRIPT_FILENAME=/ping \
+    REQUEST_METHOD=GET \
+    cgi-fcgi -bind -connect 127.0.0.1:9000 || exit 1
 
 
 


### PR DESCRIPTION
Adds a docker healthcheck using `fcgi`.

If a healthcheck is defined in the docker-compose it will take the one from the docker-compose.

The current [sample](https://github.com/tobybatch/kimai2/blob/main/compose/docker-compose.nginx.yml#L8) checks only the webserver and not the `fpm` on port `9000`.