### PR TITLE
Add apache docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,6 +160,9 @@ RUN apt-get update && \
 
 EXPOSE 8001
 
+HEALTHCHECK --interval=20s --timeout=10s --retries=3 \
+    CMD curl -f http://127.0.0.1:8001 || exit 1
+
 
 
 ###########################


### PR DESCRIPTION
Adds a docker healthcheck to the `apache` image.

Used param `-f` as described in the [Dockerfile reference](https://docs.docker.com/engine/reference/builder/#healthcheck).