### PR TITLE
Fix samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ services:
     ports:
       - 8001:80
     volumes:
-      - ./nginx_site.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx_site.conf:/etc/nginx/conf.d/default.conf
       - public:/opt/kimai/public:ro
     restart: unless-stopped
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     ports:
       - 8001:80
     volumes:
-      - ./compose/nginx_site.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./compose/nginx_site.conf:/etc/nginx/conf.d/default.conf
       - public:/opt/kimai/public:ro
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
Fixes the samples.

The `web` container does not need write-permissions for the application to work but on first start it will create a `default.conf` an therefore needs write permissions for this mount.