### PR TITLE
Better tagging for releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Kimai Dockers
-
+  
 We provide a set of docker images for the [Kimai v2](https://github.com/kevinpapst/kimai2) project.
 
 ## Quick start
 
-Run the latest master version of Kimai in production mode using a bundled DB.  **This is not suitable for production use**:
+Run the latest dev version of Kimai in production mode using a bundled DB.  **This is not suitable for production use**:
 
-    docker run --rm -ti -p 8001:8001 --name kimai kimai/kimai2
+    docker run --rm -ti -p 8001:8001 --name kimai kimai/kimai2:latest-dev
 
 Create an admin user in the new running docker:
 
@@ -16,13 +16,4 @@ This docker transient and will disappear when you stop the container.
 
 ## Documentation
 
- * [Starting a dev instance](docs/dev-instance.md#dev-instances)
- * [Using docker-compose](docs/docker-compose.md#docker-compose)
- * [All runtime arguments](docs/runtime-args.md#runtime-arguments)
- * [Building it yourself](docs/build.md#building-the-kimai-docker)
-   * [Build arguments](docs/build.md#build-arguments)
- * [Troubleshooting](docs/troubleshooting.md#troubleshooting)
-   * [NGINX and proxying](docs/troubleshooting.md#nginx-and-proxying)
-   * [Fixing permissions](docs/troubleshooting.md#permissions)
-   * [500 Server errors](docs/troubleshooting.md#500-server-errors)
-   * [Older versions](docs/troubleshooting.md#older-version)
+[https://tobybatch.github.io/kimai2/](https://tobybatch.github.io/kimai2/)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Kimai Dockers
-  
+
 We provide a set of docker images for the [Kimai v2](https://github.com/kevinpapst/kimai2) project.
 
 ## Quick start
 
-Run the latest dev version of Kimai in production mode using a bundled DB.  **This is not suitable for production use**:
+Run the latest build against tbe master branch of the Kimai repo using a bundled DB. **This is not suitable for production use**:
 
     docker run --rm -ti -p 8001:8001 --name kimai kimai/kimai2:latest-dev
 

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -4,10 +4,10 @@ function usage {
     echo
     echo "Builds all the images for the specified kimai tag and then tags them and pushes"
     echo "them:"
-    echo "  fpm-alpine-1.10.2-prod, latest, latest-prod"
-    echo "  fpm-alpine-1.10.2-dev"
-    echo "  apache-debian-1.10.2-prod"
-    echo "  apache-debian-1.10.2-dev, latest-dev"
+    echo "  fpm-alpine-X.Y.z-prod, latest, latest-prod"
+    echo "  fpm-alpine-X.Y.z-dev"
+    echo "  apache-debian-X.Y.z-prod"
+    echo "  apache-debian-X.Y.z-dev, latest-dev"
 }
 
 USAGE="$0 TAG"

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+
+function usage {
+    echo
+    echo "Builds all the images for the specified kimai tag and then tags them and pushes"
+    echo "them:"
+    echo "  fpm-alpine-1.10.2-prod, latest, latest-prod"
+    echo "  fpm-alpine-1.10.2-dev"
+    echo "  apache-debian-1.10.2-prod"
+    echo "  apache-debian-1.10.2-dev, latest-dev"
+}
+
+USAGE="$0 TAG"
+TAG=$1
+
+if [ -z "$TAG" ]; then
+  echo $USAGE
+  exit 1
+fi
+
+if [ "$TAG" == "-h" ] || [ "$TAG" == "help" ] || [ "$TAG" == "--help" ]; then # <-- maybe switch to getopts
+  echo $USAGE
+  usage
+  exit 0
+fi
+
+BIN_DIR=$(dirname $0)
+
+$BIN_DIR/build.sh -c $TAG
+$BIN_DIR/simple-test.sh $TAG
+
+set -x
+docker tag kimai/kimai2:fpm-alpine-${TAG}-prod kimai/kimai2:latest
+docker tag kimai/kimai2:fpm-alpine-${TAG}-prod kimai/kimai2:latest-prod
+docker tag kimai/kimai2:apache-debian-${TAG}-dev kimai/kimai2:latest-dev
+set +x
+
+$BIN_DIR/push.sh $TAG
+docker push kimai/kimai2:latest
+docker push kimai/kimai2:latest-prod
+docker push kimai/kimai2:latest-dev

--- a/bin/simple-test.sh
+++ b/bin/simple-test.sh
@@ -23,10 +23,8 @@ function main {
     test_container http://localhost:8002/en/login base fpm.prod nginx
     test_container http://localhost:8002/en/login base fpm.dev nginx mysql
     test_container http://localhost:8002/en/login base fpm.prod nginx mysql
-    test_container http://localhost:8001/en/login base apache.dev ldap
-    test_container http://localhost:8002/en/login base fpm.dev nginx ldap
 
-    finally
+    finally 0
 }
 
 function finally {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       retries: 3
 
   kimai:
-    image: kimai/kimai2:fpm-alpine-1.5-prod
+    image: kimai/kimai2
     environment:
       - APP_ENV=prod
       - TRUSTED_HOSTS=localhost

--- a/docs/dev-instance.md
+++ b/docs/dev-instance.md
@@ -22,7 +22,7 @@ docker exec kimai2 /opt/kimai/bin/console kimai:create-user admin admin@example.
 The containers we support are based on stable releases from the repo at
 [https://github.com/kevinpapst/kimai2](https://github.com/kevinpapst/kimai2).
 If you want to run the latest code from the Kimai repo you will need to build
-your own image locally.  You can do this from the root of the repo using this
+your own image locally. You can do this from the root of the repo using this
 command to build the image:
 
     docker build -t kimai-master --build-arg KIMAI=master .
@@ -31,4 +31,4 @@ Then you may run start a container against that image:
 
     docker run -ti --name kimai
 
-This is the FPM prod image.  See here for other build details: [build.md](build.md)
+This is the FPM prod image. See here for other build details: [build.md](build.md)

--- a/docs/dev-instance.md
+++ b/docs/dev-instance.md
@@ -16,3 +16,19 @@ docker exec kimai2 rm /opt/kimai/var/data/kimai.sqlite
 docker exec kimai2 /opt/kimai/bin/console kimai:reset-dev
 docker exec kimai2 /opt/kimai/bin/console kimai:create-user admin admin@example.com ROLE_SUPER_ADMIN changemeplease
 ```
+
+## The bleading edge
+
+The containers we support are based on stable releases from the repo at
+[https://github.com/kevinpapst/kimai2](https://github.com/kevinpapst/kimai2).
+If you want to run the latest code from the Kimai repo you will need to build
+your own image locally.  You can do this from the root of the repo using this
+command to build the image:
+
+    docker build -t kimai-master --build-arg KIMAI=master .
+
+Then you may run start a container against that image:
+
+    docker run -ti --name kimai
+
+This is the FPM prod image.  See here for other build details: [build.md](build.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,28 @@
+# Kimai Dockers
+
+We provide a set of docker images for the [Kimai v2](https://github.com/kevinpapst/kimai2) project.
+
+## Quick start
+
+Run the latest dev version of Kimai in production mode using a bundled DB.  **This is not suitable for production use**:
+
+    docker run --rm -ti -p 8001:8001 --name kimai kimai/kimai2:latest-dev
+
+Create an admin user in the new running docker:
+
+    docker exec kimai /opt/kimai/bin/console kimai:create-user admin admin@example.com ROLE_SUPER_ADMIN
+
+This docker transient and will disappear when you stop the container.
+
+## Documentation
+
+ * [Starting a dev instance](dev-instance.md#dev-instances)
+ * [Using docker-compose](docker-compose.md#docker-compose)
+ * [All runtime arguments](runtime-args.md#runtime-arguments)
+ * [Building it yourself](build.md#building-the-kimai-docker)
+   * [Build arguments](build.md#build-arguments)
+ * [Troubleshooting](troubleshooting.md#troubleshooting)
+   * [NGINX and proxying](troubleshooting.md#nginx-and-proxying)
+   * [Fixing permissions](troubleshooting.md#permissions)
+   * [500 Server errors](troubleshooting.md#500-server-errors)
+   * [Older versions](troubleshooting.md#older-version)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ We provide a set of docker images for the [Kimai v2](https://github.com/kevinpap
 
 ## Quick start
 
-Run the latest dev version of Kimai in production mode using a bundled DB.  **This is not suitable for production use**:
+Run the latest dev version of Kimai in production mode using a bundled DB. **This is not suitable for production use**:
 
     docker run --rm -ti -p 8001:8001 --name kimai kimai/kimai2:latest-dev
 
@@ -16,13 +16,13 @@ This docker transient and will disappear when you stop the container.
 
 ## Documentation
 
- * [Starting a dev instance](dev-instance.md#dev-instances)
- * [Using docker-compose](docker-compose.md#docker-compose)
- * [All runtime arguments](runtime-args.md#runtime-arguments)
- * [Building it yourself](build.md#building-the-kimai-docker)
-   * [Build arguments](build.md#build-arguments)
- * [Troubleshooting](troubleshooting.md#troubleshooting)
-   * [NGINX and proxying](troubleshooting.md#nginx-and-proxying)
-   * [Fixing permissions](troubleshooting.md#permissions)
-   * [500 Server errors](troubleshooting.md#500-server-errors)
-   * [Older versions](troubleshooting.md#older-version)
+* [Starting a dev instance](dev-instance.md#dev-instances)
+* [Using docker-compose](docker-compose.md#docker-compose)
+* [All runtime arguments](runtime-args.md#runtime-arguments)
+* [Building it yourself](build.md#building-the-kimai-docker)
+  * [Build arguments](build.md#build-arguments)
+* [Troubleshooting](troubleshooting.md#troubleshooting)
+  * [NGINX and proxying](troubleshooting.md#nginx-and-proxying)
+  * [Fixing permissions](troubleshooting.md#permissions)
+  * [500 Server errors](troubleshooting.md#500-server-errors)
+  * [Older versions](troubleshooting.md#older-version)


### PR DESCRIPTION
This PR changes the focus for tagging to provide the gold standard container (FPM Prod) as the default latest and latest-prod tag and provide latest-dev as the apache container.

This means there are no version numbers in the docs or sample compose files any more.  I'll fix the github actions to build a latest-master tag in the next couple of days and alter the docs to reflect that, but anyone after master build probably shouldn't be using a container anyway.

Thoughts welcome.