### PR TITLE
Docker-Compose Doc Fix + Version Update

### DIFF
--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -44,7 +44,7 @@ services:
       retries: 3
 
   kimai:
-    image: kimai/kimai2:fpm-alpine-1.8-prod
+    image: kimai/kimai2:fpm-alpine-1.10.2-prod
     environment:
       - APP_ENV=prod
       - TRUSTED_HOSTS=localhost,nginx,${HOSTNAME}

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -50,6 +50,7 @@ services:
       - TRUSTED_HOSTS=localhost,nginx,${HOSTNAME}
       - ADMINMAIL=admin@kimai.local
       - ADMINPASS=changemeplease
+      - DATABASE_URL=mysql://kimaiuser:kimaipassword@sqldb/kimai
     volumes:
       - public:/opt/kimai/public
       - var:/opt/kimai/var


### PR DESCRIPTION
The docker-compose documentation misses the DATABASE_URL parameter to connect to the external database. Copied the parameter from the actual docker-compose file. 

Updated to current Version.