### PR TITLE
Update PHP from 7.4.11 to 7.4.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN mkdir /opt/kimai && \
 ###########################
 
 #fpm alpine php extension base
-FROM php:7.4.11-fpm-alpine3.12 AS fpm-alpine-php-ext-base
+FROM php:7.4.12-fpm-alpine3.12 AS fpm-alpine-php-ext-base
 RUN apk add --no-cache \
     # build-tools
     autoconf \
@@ -70,7 +70,7 @@ RUN apk add --no-cache \
 
 
 # apache debian php extension base
-FROM php:7.4.11-apache-buster AS apache-debian-php-ext-base
+FROM php:7.4.12-apache-buster AS apache-debian-php-ext-base
 RUN apt-get update
 RUN apt-get install -y \
         libldap2-dev \
@@ -115,7 +115,7 @@ RUN docker-php-ext-install -j$(nproc) xsl
 ###########################
 
 # fpm-alpine base build
-FROM php:7.4.11-fpm-alpine3.12 AS fpm-alpine-base
+FROM php:7.4.12-fpm-alpine3.12 AS fpm-alpine-base
 RUN apk add --no-cache \
         bash \
         freetype \
@@ -143,7 +143,7 @@ HEALTHCHECK --interval=20s --timeout=10s --retries=3 \
 # apache-debian base build
 ###########################
 
-FROM php:7.4.11-apache-buster AS apache-debian-base
+FROM php:7.4.12-apache-buster AS apache-debian-base
 COPY 000-default.conf /etc/apache2/sites-available/000-default.conf
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
Updates PHP from 7.4.**11** to 7.4.**12**.

| Name | From | To |
|-|-|-|
| fpm-alpine-php-ext-base | php:7.4.**11**-fpm-alpine3.12 | php:7.4.**12**-fpm-alpine3.12 |
| apache-debian-php-ext-base | php:7.4.**11**-apache-buster | php:7.4.**12**-apache-buster |
| fpm-alpine-base | php:7.4.**11**-fpm-alpine3.12 | php:7.4.**12**-fpm-alpine3.12 |
| apache-debian-base | php:7.4.**11**-apache-buster | php:7.4.**12**-apache-buster |