### PR TITLE
Fix service core-kimai not found endpoint

### DIFF
--- a/docs/helm/templates/deploy-core-kimai.yml
+++ b/docs/helm/templates/deploy-core-kimai.yml
@@ -36,7 +36,7 @@ spec:
           name: core-{{ include "kimai.name" . }}
           ports:
             - containerPort: 8001
-              name: kimai
+              name: kimai-http
           resources:
             requests:
               memory: {{ .Values.kimai.resources.requests.memory }}


### PR DESCRIPTION
Fix bug in service that not found endpoint

In this image is possible see that service can't find endpoint

![image](https://user-images.githubusercontent.com/18649453/112309768-20419600-8c7a-11eb-83f6-71354cdc7945.png)


After bug fix the service find endpoint and service working

![image](https://user-images.githubusercontent.com/18649453/112309940-5ed75080-8c7a-11eb-8ecc-806ebe264f58.png)
