### PR TITLE
docs: README.md - Use absolute links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ nvm use
 npm install
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
+See [CONTRIBUTING.md](https://github.com/tobybatch/kimai2/blob/main/CONTRIBUTING.md) for more details.
 
 ## Quick start
 
@@ -51,7 +51,7 @@ This docker transient and will disappear when you stop the containers.
 
 This will run the latest prod version using FPM with an nginx reverse proxy
 
-See the [docker-compose.yml](docker-compose.yml) in the root of this repo.
+See the [docker-compose.yml](https://github.com/tobybatch/kimai2/blob/main/docker-compose.yml) in the root of this repo.
 
 ## Documentation
 


### PR DESCRIPTION
"But why?" I can hear you ask - "The links are working fine!"

Yes, they do, if you look at the README at GitHub. But the README is also displayed on [Docker](https://hub.docker.com/r/kimai/kimai2) - and the Docker people don't seem to care to absolutize the relative links to the correct origin.

With accepting this PR, you will have one person (me) less that clicks on the link at Docker and thinks "The project doesn't seem to be well-maintained" when in fact they're just not getting where the README is coming from.