### PR TITLE
added workflow file to build docker image upon kimai release

### DIFF
--- a/.github/workflows/kimai-release.yml
+++ b/.github/workflows/kimai-release.yml
@@ -1,0 +1,17 @@
+name: 'Build on Kimai release'
+
+on:
+  repository_dispatch:
+    types: [kimai_release]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run a one-line script
+        run: echo Hello, world!
+      - name: Run a multi-line script
+        run: |
+          echo Add other custom actions to build,
+          echo test, and deploy your project.


### PR DESCRIPTION
See #302 and https://github.com/kevinpapst/kimai2/pull/2882

I think this needs to be merged and then I can try to trigger events on my repo to see if this workflow starts.

Once this works we can change the contents of this workflow file to do "real work".

ping @tobybatch @Apfelwurm