### PR TITLE
fix: Docker Hub link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 We provide a set of docker images for the [Kimai v2](https://github.com/kevinpapst/kimai2) project.
 
-The built images are available from [Kimai v2](https://hub.docker.com/repository/docker/kimai/kimai2) at Docker Hub.
+The built images are available from [Kimai v2](https://hub.docker.com/r/kimai/kimai2) at Docker Hub.
 
 ## Deving and Contributing
 


### PR DESCRIPTION
The link in the README lead to a page requiring a login.
I guess you accidentally pasted the link while you were signed in to docker hub.

This new link works without being logged in.