### PR TITLE
"Quick Start" command fix + Change to mariadb container

### DIFF
--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -11,6 +11,12 @@ function waitForDB() {
     DB_HOST=$(awk -F '[/:@]' '{print $6}' <<< $DATABASE_URL)
     DB_PORT=$(awk -F '[/:@]' '{print $7}' <<< $DATABASE_URL)
     DB_BASE=$(awk -F '[/?]' '{print $4}' <<< $DATABASE_URL)
+
+    re='^[0-9]+$'
+    if ! [[ $DB_PORT =~ $re ]] ; then
+       DB_PORT=3306
+    fi
+
   else
     DB_TYPE=${DB_TYPE:mysql}
     if [ "$DB_TYPE" == "mysql" ]; then
@@ -19,11 +25,6 @@ function waitForDB() {
       echo "Unknown database type, cannot proceed. Only 'mysql' is supported, received: [$DB_TYPE]"
       exit 1
     fi
-  fi
-
-  re='^[0-9]+$'
-  if ! [[ $DB_PORT =~ $re ]] ; then
-     DB_PORT=3306
   fi
 
   echo "Wait for MySQL DB connection ..."

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -14,7 +14,7 @@ function waitForDB() {
   else
     DB_TYPE=${DB_TYPE:mysql}
     if [ "$DB_TYPE" == "mysql" ]; then
-      export DATABASE_URL="${DB_TYPE}://${DB_USER:=kimai}:${DB_PASS:=kimai}@${DB_HOST:=sqldb}:${DB_PORT:=3306}/${DB_BASE:=kimai}"
+      export DATABASE_URL="${DB_TYPE}://${DB_USER:=kimai}:${DB_PASS:=kimai}@${DB_HOST:=database}:${DB_PORT:=3306}/${DB_BASE:=kimai}"
     else
       echo "Unknown database type, cannot proceed. Only 'mysql' is supported, received: [$DB_TYPE]"
       exit 1
@@ -36,7 +36,7 @@ function waitForDB() {
 
 function handleStartup() {
   # These are idempotent, run them anyway
-  tar -zx -C /opt/kimai -f /var/tmp/public.tgz 
+  tar -zx -C /opt/kimai -f /var/tmp/public.tgz
   /opt/kimai/bin/console -n kimai:install
   /opt/kimai/bin/console -n kimai:update
   if [ ! -z "$ADMINPASS" ] && [ ! -a "$ADMINMAIL" ]; then

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -20,7 +20,7 @@ function waitForDB() {
   else
     DB_TYPE=${DB_TYPE:mysql}
     if [ "$DB_TYPE" == "mysql" ]; then
-      export DATABASE_URL="${DB_TYPE}://${DB_USER:=kimai}:${DB_PASS:=kimai}@${DB_HOST:=database}:${DB_PORT:=3306}/${DB_BASE:=kimai}"
+      export DATABASE_URL="${DB_TYPE}://${DB_USER:=kimai}:${DB_PASS:=kimai}@${DB_HOST:=sqldb}:${DB_PORT:=3306}/${DB_BASE:=kimai}"
     else
       echo "Unknown database type, cannot proceed. Only 'mysql' is supported, received: [$DB_TYPE]"
       exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.5'
 services:
 
-  database:
+  sqldb:
     image: mariadb:latest
     environment:
       - MYSQL_DATABASE=kimai

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     environment:
       - ADMINMAIL=admin@kimai.local
       - ADMINPASS=changemeplease
-      - DATABASE_URL=mysql://kimaiuser:kimaipassword@sqldb/kimai
+      - DATABASE_URL=mysql://kimaiuser:kimaipassword@sqldb:3306/kimai
       - TRUSTED_HOSTS=nginx,localhost,127.0.0.1
     volumes:
       - public:/opt/kimai/public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3.5'
 services:
 
-  sqldb:
-    image: mysql:5.7
+  database:
+    image: mariadb:latest
     environment:
       - MYSQL_DATABASE=kimai
       - MYSQL_USER=kimaiuser


### PR DESCRIPTION
The 2 commands specified in the website https://tobybatch.github.io/kimai2/ do not work as is:
```
docker run --rm --name kimai-test -ti -p 8001:8001 -e DATABASE_URL=mysql://kimai:kimai@${HOSTNAME}:3399/kimai kimai/kimai2:apache

Wait for MySQL DB connection ...
PHP Warning:  Undefined array key 5 in /dbtest.php on line 6
Testing DB:** new \PDO(mysql:host=kimai;dbname=3399;port=kimai, kimai, , [ \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION ]);*SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Temporary failure in name resolution (?)Checking DB: 10
```

The variable `DB_PORT` (array 5 undefined error) must be set in the DB connection parameter.

Bonus : changed from mysql to mariadb ;)