### PR TITLE
chore: build arm64 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,14 @@ ARG BASE="fpm"
 ###########################
 
 # full kimai source
-FROM alpine:3.15.0 AS git-dev
+FROM alpine:3.15 AS git-dev
 ARG KIMAI="master"
+ARG REPO="https://github.com/kevinpapst/kimai2.git"
 # I need to do this check somewhere, we discard all but the checkout so doing here doesn't hurt
 ADD assets/test-kimai-version.sh /test-kimai-version.sh
 RUN /test-kimai-version.sh
 RUN apk add --no-cache git && \
-    git clone --depth 1 --branch ${KIMAI} https://github.com/kevinpapst/kimai2.git /opt/kimai
+    git clone --depth 1 --branch ${KIMAI} ${REPO} /opt/kimai
 
 # production kimai source
 FROM git-dev AS git-prod
@@ -27,7 +28,7 @@ WORKDIR /opt/kimai
 RUN rm -r tests
 
 # composer base image
-FROM composer:2.3.5 AS composer
+FROM composer:2 AS composer
 
 
 ###########################
@@ -35,7 +36,7 @@ FROM composer:2.3.5 AS composer
 ###########################
 
 #fpm alpine php extension base
-FROM php:8.0.15-fpm-alpine3.15 AS fpm-php-ext-base
+FROM php:8.0-fpm-alpine3.15 AS fpm-php-ext-base
 RUN apk add --no-cache \
     # build-tools
     autoconf \
@@ -70,7 +71,7 @@ RUN apk add --no-cache \
 
 
 # apache debian php extension base
-FROM php:8.0.14-apache-buster AS apache-php-ext-base
+FROM php:8.0-apache-buster AS apache-php-ext-base
 RUN apt-get update
 RUN apt-get install -y \
         libldap2-dev \

--- a/Makefile
+++ b/Makefile
@@ -8,38 +8,89 @@ ifndef KIMAI_VERSION
   KIMAI_VERSION := master
 endif
 
+ifndef KIMAI_REPO
+	KIMAI_REPO := https://github.com/kevinpapst/kimai2.git
+endif
+
+ifndef KIMAI_IMG
+	KIMAI_IMG := kimai/kimai2
+endif
+
 ZAP := $(shell echo $(KIMAI_VERSION) | egrep -q "[0-9].[0-9]+" && echo matched)
 
+.PHONY: buildx
+buildx:
+	docker buildx build \
+		--platform linux/amd64,linux/arm64 \
+		--build-arg KIMAI=${KIMAI_VERSION} \
+		--build-arg REPO=${KIMAI_REPO} \
+		--build-arg BASE=fpm \
+		--build-arg TZ=${TIMEZONE} \
+		--target=dev \
+		-t ${KIMAI_IMG}:fpm-dev \
+		-t ${KIMAI_IMG}:latest-dev \
+		.
+	docker buildx build \
+		--platform linux/amd64,linux/arm64 \
+		--build-arg KIMAI=${KIMAI_VERSION} \
+		--build-arg REPO=${KIMAI_REPO} \
+		--build-arg BASE=fpm \
+		--build-arg TZ=${TIMEZONE} \
+		--target=prod \
+		-t ${KIMAI_IMG}:fpm-prod \
+		-t ${KIMAI_IMG}:fpm \
+		-t ${KIMAI_IMG}:latest \
+		.
+	docker buildx build \
+		--platform linux/amd64,linux/arm64 \
+		--build-arg KIMAI=${KIMAI_VERSION} \
+		--build-arg REPO=${KIMAI_REPO} \
+		--build-arg BASE=apache \
+		--build-arg TZ=${TIMEZONE} \
+		--target=dev \
+		-t ${KIMAI_IMG}:apache-dev \
+		.
+	docker buildx build \
+		--platform linux/amd64,linux/arm64 \
+		--build-arg KIMAI=${KIMAI_VERSION} \
+		--build-arg REPO=${KIMAI_REPO} \
+		--build-arg BASE=apache \
+		--build-arg TZ=${TIMEZONE} \
+		--target=prod \
+		-t ${KIMAI_IMG}:apache-prod \
+		-t ${KIMAI_IMG}:apache \
+		.
+
 build:
-	docker build -t kimai/kimai2:fpm-${KIMAI_VERSION}-dev --build-arg KIMAI=${KIMAI_VERSION} --build-arg BASE=fpm --build-arg TZ=${TIMEZONE} --target=dev .
-	docker build -t kimai/kimai2:fpm-${KIMAI_VERSION}-prod --build-arg KIMAI=${KIMAI_VERSION} --build-arg BASE=fpm --build-arg TZ=${TIMEZONE} --target=prod .
-	docker build -t kimai/kimai2:apache-${KIMAI_VERSION}-dev --build-arg KIMAI=${KIMAI_VERSION} --build-arg BASE=apache --build-arg TZ=${TIMEZONE} --target=dev .
-	docker build -t kimai/kimai2:apache-${KIMAI_VERSION}-prod --build-arg KIMAI=${KIMAI_VERSION} --build-arg BASE=apache --build-arg TZ=${TIMEZONE} --target=prod .
+	docker build -t ${KIMAI_IMG}:fpm-${KIMAI_VERSION}-dev --build-arg KIMAI=${KIMAI_VERSION} --build-arg BASE=fpm --build-arg TZ=${TIMEZONE} --target=dev .
+	docker build -t ${KIMAI_IMG}:fpm-${KIMAI_VERSION}-prod --build-arg KIMAI=${KIMAI_VERSION} --build-arg BASE=fpm --build-arg TZ=${TIMEZONE} --target=prod .
+	docker build -t ${KIMAI_IMG}:apache-${KIMAI_VERSION}-dev --build-arg KIMAI=${KIMAI_VERSION} --build-arg BASE=apache --build-arg TZ=${TIMEZONE} --target=dev .
+	docker build -t ${KIMAI_IMG}:apache-${KIMAI_VERSION}-prod --build-arg KIMAI=${KIMAI_VERSION} --build-arg BASE=apache --build-arg TZ=${TIMEZONE} --target=prod .
 
 tag:
 ifeq (${ZAP}, matched)
-	docker tag kimai/kimai2:fpm-${KIMAI_VERSION}-prod kimai/kimai2:fpm
-	docker tag kimai/kimai2:fpm-${KIMAI_VERSION}-dev kimai/kimai2:fpm-dev
-	docker tag kimai/kimai2:apache-${KIMAI_VERSION}-prod kimai/kimai2:apache
-	docker tag kimai/kimai2:apache-${KIMAI_VERSION}-dev kimai/kimai2:apache-dev
-	docker tag kimai/kimai2:fpm-${KIMAI_VERSION}-prod kimai/kimai2:latest
-	docker tag kimai/kimai2:apache-${KIMAI_VERSION}-dev kimai/kimai2:latest-dev
+	docker tag ${KIMAI_IMG}:fpm-${KIMAI_VERSION}-prod kimai/kimai2:fpm
+	docker tag ${KIMAI_IMG}:fpm-${KIMAI_VERSION}-dev kimai/kimai2:fpm-dev
+	docker tag ${KIMAI_IMG}:apache-${KIMAI_VERSION}-prod kimai/kimai2:apache
+	docker tag ${KIMAI_IMG}:apache-${KIMAI_VERSION}-dev kimai/kimai2:apache-dev
+	docker tag ${KIMAI_IMG}:fpm-${KIMAI_VERSION}-prod kimai/kimai2:latest
+	docker tag ${KIMAI_IMG}:apache-${KIMAI_VERSION}-dev kimai/kimai2:latest-dev
 else
 	$(error ${KIMAI_VERSION} does not look like a release, x.y or x.y.z. Not tagging)
 endif
 
 push:
-	docker push kimai/kimai2:fpm-${KIMAI_VERSION}-dev
-	docker push kimai/kimai2:fpm-${KIMAI_VERSION}-prod
-	docker push kimai/kimai2:apache-${KIMAI_VERSION}-dev
-	docker push kimai/kimai2:apache-${KIMAI_VERSION}-prod
+	docker push ${KIMAI_IMG}:fpm-${KIMAI_VERSION}-dev
+	docker push ${KIMAI_IMG}:fpm-${KIMAI_VERSION}-prod
+	docker push ${KIMAI_IMG}:apache-${KIMAI_VERSION}-dev
+	docker push ${KIMAI_IMG}:apache-${KIMAI_VERSION}-prod
 ifeq (${ZAP}, matched)
-	docker push kimai/kimai2:fpm
-	docker push kimai/kimai2:fpm-dev
-	docker push kimai/kimai2:apache
-	docker push kimai/kimai2:apache-dev
-	docker push kimai/kimai2:latest
-	docker push kimai/kimai2:latest-dev
+	docker push ${KIMAI_IMG}:fpm
+	docker push ${KIMAI_IMG}:fpm-dev
+	docker push ${KIMAI_IMG}:apache
+	docker push ${KIMAI_IMG}:apache-dev
+	docker push ${KIMAI_IMG}:latest
+	docker push ${KIMAI_IMG}:latest-dev
 endif
 
 clean-test:


### PR DESCRIPTION
This is a preliminary PR to work on enabling arm64 images to be built as part of the general release cycle.

I'm a bit unclear on your exact desired deploy process, but the high level goals of these changes are:

1. Utilize [Docker buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/) integration to facilitate [multi-arch](https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images) images
2. Update Makefile and Dockerfile with a few nice-to-haves for contributors to be able to develop from their own forks.

The `buildx` target _works_, but as I mentioned it is not inherently clear to me on how you would prefer this to be handled, so any suggestions / questions are welcome so we can get this moving :)