### PR TITLE
[DOCS] README: ports in Quick start commands don't match

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Run the latest production build:
             -e MYSQL_USER=kimai \
             -e MYSQL_PASSWORD=kimai \
             -e MYSQL_ROOT_PASSWORD=kimai \
-            -p 3399:3306 -d mysql
+            -p 3306:3306 -d mysql
         
  1. Start Kimai 
    

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ Run the latest production build:
             -e MYSQL_USER=kimai \
             -e MYSQL_PASSWORD=kimai \
             -e MYSQL_ROOT_PASSWORD=kimai \
-            -p 3306:3306 -d mysql
+            -p 3399:3306 -d mysql
         
  1. Start Kimai 
    
         docker run --rm --name kimai-test \
             -ti \
             -p 8001:8001 \
-            -e DATABASE_URL=mysql://kimai:kimai@${HOSTNAME}:3306/kimai \
+            -e DATABASE_URL=mysql://kimai:kimai@${HOSTNAME}:3399/kimai \
             kimai/kimai2:apache
  
 Note: If you're using Docker for Windows or Docker for Mac, and you're getting "Connection refused" or other errors, you might need to change `${HOSTNAME}` to `host.docker.internal`. This is because the Kimai Docker container can only communicate within its network boundaries. Another option would be to start the container with the flag `--network="host"`. See [here](https://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach) for more information.


### PR DESCRIPTION
Hi there! Just a quick thing someone new to docker could stumble upon:

Running both docker commands in the README's Quick start section will result in the kimai container not connecting to the DB.
The DB container exposes port `3399`, but the DATABASE_URL of the kimai container is set to listen on port `3306`.

Proposed fix: changing the exposed port of the DB container to `3306`