### PR TITLE
fix: disable auto build on push

### DIFF
--- a/.github/workflows/kimai-release.yml
+++ b/.github/workflows/kimai-release.yml
@@ -2,8 +2,8 @@ name: 'Build release'
 
 on:
   workflow_dispatch:
-  repository_dispatch:
-    types: [kimai_release]
+  # repository_dispatch:
+    # types: [kimai_release]
 
 jobs:
   build:


### PR DESCRIPTION
The workflow auto builds the highest numbered version it can find and currently that's the v2 beta build. Rather than re-working the CI, we'll just disable the workflow for now and you can just ping me when you release and I'll do a manual build.

When v2 is released, we'll re-enable it