### PR TITLE
docs: index.md updated with working commands

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,27 +2,63 @@
 
 We provide a set of docker images for the [Kimai v2](https://github.com/kevinpapst/kimai2) project.
 
+The built images are available from [Kimai v2](https://hub.docker.com/r/kimai/kimai2) at Docker Hub.
+
 ## Quick start
 
 Run the latest production build:
 
- 1. Start a DB
+1. Start a DB
 
-        docker run --rm --name kimai-mysql-testing -e MYSQL_DATABASE=kimai -e MYSQL_USER=kimai -e MYSQL_PASSWORD=kimai -e MYSQL_ROOT_PASSWORD=kimai -p 3399:3306 -d mysql
+    ```bash
+        docker run --rm --name kimai-mysql-testing \
+            -e MYSQL_DATABASE=kimai \
+            -e MYSQL_USER=kimai \
+            -e MYSQL_PASSWORD=kimai \
+            -e MYSQL_ROOT_PASSWORD=kimai \
+            -p 3399:3306 -d mysql
+    ```
 
- 1. Start Kimai
+2. Start Kimai
 
-        docker run --rm --name kimai-test -ti -p 8001:8001 -e DATABASE_URL=mysql://kimai:kimai@${HOSTNAME}:3399/kimai kimai/kimai2:apache
+    ```bash
+        docker run --rm --name kimai-test \
+            -ti \
+            -p 8001:8001 \
+            -e DATABASE_URL=mysql://kimai:kimai@${HOSTNAME}:3399/kimai \
+            kimai/kimai2:apache
+    ```
 
- 1. Add a user, open a new terminal and:
+3. Add a user using the terminal
 
-        docker exec -ti kimai-test /bin/console kimai:create-user admin admin@example.com ROLE_SUPER_ADMIN
+    ```bash
+        docker exec -ti kimai-test \
+            /opt/kimai/bin/console kimai:create-user admin admin@example.com ROLE_SUPER_ADMIN
+    ```
 
-You can now hit the kimai instance on <http://localhost:8001>
+Now, you can access the Kimai instance at <http://localhost:8001>.
 
-This docker transient and will disappear when you stop the containers.
+__Note:__
+If you're using Docker for Windows or Docker for Mac, and you're getting "Connection refused" or other errors, you might need to change `${HOSTNAME}` to `host.docker.internal`.
+This is because the Kimai Docker container can only communicate within its network boundaries. Alternatively, you can start the container with the flag `--network="host"`.
+See [here](https://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach) for more information.
 
+Keep in mind that this Docker setup is transient and the data will disappear when you remove the containers.
+
+```bash
     docker stop kimai-mysql-testing kimai-test
+    docker rm kimai-mysql-testing kimai-test
+```
+
+## Using docker-compose
+
+This will run the latest prod version using FPM with an nginx reverse proxy
+
+See the [[docker-compose.yml](https://github.com/tobybatch/kimai2/blob/main/docker-compose.yml)] in the root of this repo.
+
+## Documentation
+
+[https://tobybatch.github.io/kimai2/](https://tobybatch.github.io/kimai2/)
 
 ## Documentation
 


### PR DESCRIPTION
The commands stated in the index.md aren't working anymore, so I've updated them from the readme.md with additional details (docker-compose, notes for Docker for Windows/Mac).

fixes #481 