### PR TITLE
fix(assets): change create user command for new version

### DIFF
--- a/assets/service.sh
+++ b/assets/service.sh
@@ -37,7 +37,7 @@ function handleStartup() {
   /opt/kimai/bin/console -n kimai:install
   /opt/kimai/bin/console -n kimai:update
   if [ ! -z "$ADMINPASS" ] && [ ! -a "$ADMINMAIL" ]; then
-    /opt/kimai/bin/console kimai:create-user superadmin "$ADMINMAIL" ROLE_SUPER_ADMIN "$ADMINPASS"
+    /opt/kimai/bin/console kimai:user:create superadmin "$ADMINMAIL" ROLE_SUPER_ADMIN "$ADMINPASS"
   fi
   echo "$KIMAI" > /opt/kimai/var/installed
   echo "Kimai2 ready"


### PR DESCRIPTION
This commit fix the following error :

```
/opt/kimai/bin/console kimai:create-user superadmin 'foo@example.net' ROLE_SUPER_ADMIN testpass
The command "kimai:reset:locales" does not exist.
```

New syntax is `kimai:user:create`