### PR TITLE
Fix #511: Add icu-data-full package to fpm image Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN apk add --no-cache \
     libpng-dev \
     # icu
     icu-dev \
+    icu-data-full \
     # ldap
     openldap-dev \
     libldap \
@@ -140,6 +141,7 @@ RUN apk add --no-cache \
         freetype \
         haveged \
         icu \
+        icu-data-full \
         libldap \
         libpng \
         libzip \


### PR DESCRIPTION
Fixes https://github.com/tobybatch/kimai2/issues/511
Now number and currency formatting should work fine in the fpm docker image
