### PR TITLE
fix(assets): Ensure apache2/fpm running as PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -265,7 +265,7 @@ ENV GROUP_ID=
 
 VOLUME [ "/opt/kimai/var" ]
 
-ENTRYPOINT /startup.sh
+CMD [ "/startup.sh" ]
 
 
 

--- a/assets/service.sh
+++ b/assets/service.sh
@@ -48,7 +48,7 @@ function runServer() {
   /opt/kimai/bin/console kimai:reload --env="$APP_ENV"
   chown -R $USER_ID:$GROUP_ID /opt/kimai/var
   if [ -e /use_apache ]; then
-    /usr/sbin/apache2ctl -D FOREGROUND
+    exec /usr/sbin/apache2 -D FOREGROUND
   elif [ -e /use_fpm ]; then
     exec php-fpm
   else
@@ -59,4 +59,3 @@ function runServer() {
 waitForDB
 handleStartup
 runServer
-exit

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -80,10 +80,14 @@ function handleStartup() {
   fi
 
   if [ -e /use_apache ]; then
-    echo "APACHE_RUN_USER=$(id -nu "$USER_ID")" >> /etc/apache2/envvars
+    export APACHE_RUN_USER=$(id -nu "$USER_ID")
     # This doesn't _exactly_ run as the specified GID, it runs as the GID of the specified user but WTF
-    echo "APACHE_RUN_GROUP=$(id -ng "$USER_ID")" >> /etc/apache2/envvars
-    tail -n2 /etc/apache2/envvars
+    export APACHE_RUN_GROUP=$(id -ng "$USER_ID")
+    export APACHE_PID_FILE=/var/run/apache2/apache2.pid
+    export APACHE_RUN_DIR=/var/run/apache2
+    export APACHE_LOCK_DIR=/var/lock/apache2
+    export APACHE_LOG_DIR=/var/log/apache2
+    export LANG=C
   elif [ -e /use_fpm ]; then
     sed -i "s/user = .*/user = $USER_ID/g" /usr/local/etc/php-fpm.d/www.conf
     sed -i "s/group = .*/group = $GROUP_ID/g" /usr/local/etc/php-fpm.d/www.conf
@@ -96,5 +100,4 @@ function handleStartup() {
 config
 handleStartup
 
-/service.sh
-exit
+exec /service.sh


### PR DESCRIPTION
In order to stop container quickly, we need to run apache2 or fpm as PID 1

* Use CMD "exec form" instead of "shell form"
* Use exec "binary" instead of "binary"
* Use apache2 instead of apache2ctl
* See also https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact