### PR TITLE
deactivate arm/v8 as 32bit is not supported any longer

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -44,7 +44,7 @@ jobs:
             TIMEZONE=Europe/London
             BASE=${{ matrix.server }}
           target: ${{ matrix.type }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v8 #,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64 #,linux/arm/v8,linux/arm/v7,linux/arm/v6
           tags: |
             kimai/kimai2:${{ matrix.server }}-${{ matrix.type }}
             kimai/kimai2:${{ matrix.server }}-${{steps.remote_version.outputs.version}}-${{ matrix.type }}

--- a/.github/workflows/kimai-release.yml
+++ b/.github/workflows/kimai-release.yml
@@ -43,7 +43,7 @@ jobs:
             TIMEZONE=Europe/London
             BASE=${{ matrix.server }}
           target: ${{ matrix.type }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v8 #,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64 #,linux/arm/v8,linux/arm/v7,linux/arm/v6
           tags: |
             kimai/kimai2:${{ matrix.server }}-${{ matrix.type }}
             kimai/kimai2:${{ matrix.server }}-${{steps.remote_version.outputs.version}}-${{ matrix.type }}


### PR DESCRIPTION
See https://github.com/tobybatch/kimai2/actions/runs/6009925965

Fixes hopefully the last problem with 32-bit builds.

