### PR TITLE
Change the Kimai repository URL

### DIFF
--- a/.github/workflows/build-default.yml
+++ b/.github/workflows/build-default.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: get lastest version
         id: remote_version
-        run: echo "::set-output name=version::$(lastversion https://github.com/kevinpapst/kimai2)"
+        run: echo "::set-output name=version::$(lastversion https://github.com/kimai/kimai)"
 
       - name: Build
         uses: docker/build-push-action@v2

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: get lastest version
         id: remote_version
-        run: echo "::set-output name=version::$(lastversion https://github.com/kevinpapst/kimai2)"
+        run: echo "::set-output name=version::$(lastversion https://github.com/kimai/kimai)"
 
       - name: Build
         uses: docker/build-push-action@v2

--- a/.github/workflows/kimai-release.yml
+++ b/.github/workflows/kimai-release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: get lastest version
         id: remote_version
-        run: echo "::set-output name=version::$(lastversion https://github.com/kevinpapst/kimai2)"
+        run: echo "::set-output name=version::$(lastversion https://github.com/kimai/kimai)"
 
       - name: Build
         uses: docker/build-push-action@v2

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Kimai Dockers
 
-We provide a set of docker images for the [Kimai v2](https://github.com/kevinpapst/kimai2) project.
+We provide a set of docker images for the [Kimai](https://github.com/kimai/kimai) project.
 
-The built images are available from [Kimai v2](https://hub.docker.com/r/kimai/kimai2) at Docker Hub.
+The built images are available from [Kimai](https://hub.docker.com/r/kimai/kimai2) at Docker Hub.
 
 ## Deving and Contributing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # Kimai Dockers
 
-We provide a set of docker images for the [Kimai v2](https://github.com/kevinpapst/kimai2) project.
+We provide a set of docker images for the [Kimai](https://github.com/kimai/kimai) project.
 
-The built images are available from [Kimai v2](https://hub.docker.com/r/kimai/kimai2) at Docker Hub.
+The built images are available from [Kimai](https://hub.docker.com/r/kimai/kimai2) at Docker Hub.
 
 ## Quick start
 


### PR DESCRIPTION
With the major version change to 2.0 Kimai moved to the new repository within the Kimai organization:
https://github.com/kimai/kimai

I think it should be save to simply change all URLs here. 